### PR TITLE
Add debug logging and fix verb_realization loop

### DIFF
--- a/greek_verbs/src/anki_flashcard.py
+++ b/greek_verbs/src/anki_flashcard.py
@@ -1,18 +1,21 @@
 import click
 import json
+import logging
 from os.path import join, dirname
-
+from greek_verbs.src.helpers import logger_setup
 
 class Attribute():
     pass
 
 
-def conjugation_to_html(verb: str, conj: dict) -> str:
+def conjugation_to_html(conj: dict, logger: logging.Logger) -> str:
     """
     Convert the conjugation dictionary output of `get_conjugation()`
     to HTML that will populate the Anki flashcard and will be automatically
     parsed by Anki in tabular format.
     """
+    logger.debug('Formatting conjugation dictionary to HTML')
+
     vars = Attribute()
     for k, v in conj.items():
         setattr(vars, k, v)
@@ -24,37 +27,49 @@ def conjugation_to_html(verb: str, conj: dict) -> str:
         html_template = f.read()
         html_template = html_template.format(**locals())
 
+    logger.debug('Created conjugation HTML')
     return html_template
 
 
-def format_example_usages(conj: dict, example_usages: dict, num_examples: int) -> str:
+def format_example_usages(conj: dict, example_usages: dict, num_examples: int, logger: logging.Logger) -> str:
     """
     Extract example usages from the conjugation and format them for
     an Anki flashcard. The input is a dictionary with key:value pairs
     of Greek:English for each example usage.
     """
     if len(example_usages):
+        logger.debug(f'Formatting {len(example_usages)} example usages as HTML')
         template = '{greek}<br><em>{english}</em>'
 
         usages = []
         for i, (greek, english) in enumerate(example_usages.items()):
+            logger.debug(f'Example usage {i}', arrow='black')
+
             if i == num_examples: break
             clean_usage = lambda x: x.replace('#', '').strip().strip('-').strip().strip('"').strip()
 
+            logger.debug(f'Greek "{greek}"', arrow='black', indent=1)
             greek = clean_usage(greek)
+            logger.debug(f'Greek (cleaned) "{greek}"', arrow='black', indent=1)
+            logger.debug(f'English "{english}"', arrow='black', indent=1)
             english = clean_usage(english)
+            logger.debug(f'English (cleaned) "{english}"', arrow='black', indent=1)
             usage = template.format(greek=greek, english=english)
+            logger.debug(f'Sample usage "{usage}"', indent=1)
 
-            for conj_name, conj_realization in conj.items():
-                usage = usage.replace(conj_realization, f'<b>{conj_realization}</b>')
+            verb_inflections = list(set([x for x in conj.values() if x > '']))
+            for inflection in verb_inflections:
+                logger.debug(f'Bolding "{inflection}" in usage', indent=1)
+                usage = usage.replace(inflection, f'<b>{inflection}</b>')
 
             usages.append(usage)
 
         usages_str = '<br><br>'.join(usages)
+        logger.debug('Created example usages HTML')
         return usages_str
     else:
+        logger.debug('No example usages found')
         return ''
-
 
 @click.option('--verb', type=str, required=True,
               help='Verb to prepare flashcard for.')
@@ -62,28 +77,46 @@ def format_example_usages(conj: dict, example_usages: dict, num_examples: int) -
               help='Path to conjugations JSON file.')
 @click.option('--num-examples', type=int, default=None,
               help='Configurable number to limit the number of examples displayed')
-
+@click.option('--debug', is_flag=True, default=False,
+              help='Enable verbose debug logging.')
 
 @click.command()
-def anki_flashcard(verb: str, conjugations_json: str, num_examples: int) -> None:
+def anki_flashcard(verb: str, conjugations_json: str, num_examples: int, debug: bool) -> None:
     """
     Build Anki flashcard for a given verb.
     """
+    logging_level = logging.DEBUG if debug else logging.ERROR
+    logger = logger_setup(name='anki_flashcard', level=logging_level)
+    logger.debug(f"Creating Anki flashcard for '{verb}'")
+
     with open(conjugations_json, 'r') as f:
+        logger.debug(f'Loading verb conjugations at "{conjugations_json}"')
         verb_conjugations = json.load(f)
 
     verb = verb.lower()
     if verb in verb_conjugations:
-        conjugation_table_str = conjugation_to_html(verb, verb_conjugations[verb]['conjugation'])
-        example_usage_str = format_example_usages(verb_conjugations[verb]['conjugation'], verb_conjugations[verb]['example_usages'], num_examples)
+        conjugation_table_str = conjugation_to_html(
+            conj=verb_conjugations[verb]['conjugation'],
+            logger=logger,
+        )
+        example_usage_str = format_example_usages(
+            conj=verb_conjugations[verb]['conjugation'],
+            example_usages=verb_conjugations[verb]['example_usages'],
+            num_examples=num_examples,
+            logger=logger,
+        )
+
+        logger.debug('Assembling flashcard')
 
         anki_flashcard_str = verb
         anki_flashcard_str += '<br><br>'
         anki_flashcard_str+= conjugation_table_str
+
         if len(example_usage_str) > 0:
             anki_flashcard_str += '<br>'
             anki_flashcard_str += example_usage_str
 
         print(f'{anki_flashcard_str}')
+        logger.debug('Flashcard assembled')
     else:
         print(f"No such verb found '{verb}'!")

--- a/greek_verbs/src/helpers.py
+++ b/greek_verbs/src/helpers.py
@@ -1,0 +1,85 @@
+import click
+import logging
+import re
+import threading
+
+
+class ExtendedLogger(logging.Logger):
+    """
+    Extend the logging.Logger class.
+    """
+    def __init__(self, name, level=logging.NOTSET) -> None:
+        self._count = 0
+        self._countLock = threading.Lock()
+        return super(ExtendedLogger, self).__init__(name, level)
+
+    def _build_message(self, msg: str, arrow: str=None, indent: int=0, bold: bool=False) -> str:
+        """
+        Apply format parameters to a raw string.
+        """
+        msg = re.sub(r'\s+', ' ', str(msg).strip())
+
+        if bold:
+            msg = click.style(msg, bold=True)
+
+        arrow_str = click.style('> ', fg=arrow, bold=True) if arrow is not None else ''
+        indent_str = '  ' * indent
+
+        msg = str(msg)
+        return f'{indent_str} {arrow_str}{msg}'
+
+    def debug(self, msg: str, *args, **kwargs):
+        """
+        Override the logging.Logger.debug() method and support the formatting in self._build_message().
+        """
+        formatted_msg = self._build_message(msg, *args, **kwargs)
+        return super(ExtendedLogger, self).debug(formatted_msg)
+
+    def info(self, msg: str, *args, **kwargs):
+        """
+        Override the logging.Logger.info() method and support the formatting in self._build_message().
+        """
+        formatted_msg = self._build_message(msg, *args, **kwargs)
+        return super(ExtendedLogger, self).info(formatted_msg)
+
+    def warning(self, msg: str, *args, **kwargs):
+        """
+        Override the logging.Logger.warning() method and support the formatting in self._build_message().
+        """
+        formatted_msg = self._build_message(msg, *args, **kwargs)
+        return super(ExtendedLogger, self).warning(formatted_msg)
+
+    def error(self, msg: str, *args, **kwargs):
+        """
+        Override the logging.Logger.error() method and support the formatting in self._build_message().
+        """
+        formatted_msg = self._build_message(msg, *args, **kwargs)
+        return super(ExtendedLogger, self).error(formatted_msg)
+
+    def critical(self, msg: str, *args, **kwargs):
+        """
+        Override the logging.Logger.critical() method and support the formatting in self._build_message().
+        """
+        formatted_msg = self._build_message(msg, *args, **kwargs)
+        return super(ExtendedLogger, self).critical(formatted_msg)
+
+
+
+def logger_setup(name: str=__name__, level: int=logging.DEBUG) -> logging.Logger:
+    """
+    Set up standard logger.
+    """
+    logging.setLoggerClass(ExtendedLogger)
+    logger = logging.getLogger(name)
+    formatter = logging.Formatter('%(asctime)s : %(levelname)s : %(name)s : %(message)s')
+
+    if logger.hasHandlers():
+        logger.handlers.clear()
+
+    console_handler = logging.StreamHandler()
+    console_handler.setLevel(level)
+    console_handler.setFormatter(formatter)
+    logger.addHandler(console_handler)
+
+    logger.setLevel(level)
+    return logger


### PR DESCRIPTION
**Added**
- debug logging with ``ExtendedLogger``

**Changed**

**Deprecated**

**Removed**

**Fixed**
- ``for`` loop inside ``format_example_usages()`` , previously in this line ``usage.replace(verb_realization, f'<b>{verb_realization}</b>')`` the ``verb_realization`` was equal to ``''`` which caused malformatting of the HTML string and caused the loop to take a significant amount of time (5-10 seconds per loop) for some verbs. This is now fixed by first getting a unique list of verb inflections that are ``>''``, then bolding those in the HTML string ``usage``

**Security**